### PR TITLE
calculated DOCKER_REGISTRY for skaffold run

### DIFF
--- a/watch.sh
+++ b/watch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+export DOCKER_REGISTRY="${JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}:${JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}"
 skaffold run -p dev
 
 echo ""


### PR DESCRIPTION
The variable DOCKER_REGISTRY was blank in the skaffold.yaml file and was therefore failing. 
This is a workaround 